### PR TITLE
Set the Content-Type header to 'application/json'

### DIFF
--- a/lib/rpcjson.rb
+++ b/lib/rpcjson.rb
@@ -26,12 +26,13 @@ class RPC
           @http.finish
           @http = Net::HTTP.start(@uri.host, @uri.port)
         end
-        request = Net::HTTP::Post.new(@uri.request_uri)
-	if @uri.user != nil
+        request = Net::HTTP::Post.new(@uri.request_uri,
+                                      {'Content-Type' => 'application/json'})
+        if @uri.user != nil
           request.basic_auth(@uri.user, @uri.password)
-	end
-	request.body = body
-	response = @http.request(request)
+        end
+        request.body = body
+        response = @http.request(request)
         JSON( response.body )
       end
 


### PR DESCRIPTION
This allows rpcjson to interoperate with stricter servers that reject the standard Content-Type header that Net::HTTP uses for POST requests. ie: application/x-www-form-urlencoded

It also fixes a slight whitespace issue which I can split into another commit if you like.
